### PR TITLE
Change export name to decorateHyper to fix issue #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.decorateConfig = (config) => {
   });
 }
 
-exports.decorateHyperTerm = (HyperTerm, { React, notify }) => {
+exports.decorateHyper = (HyperTerm, { React, notify }) => {
   return class extends React.Component {
     constructor(props, context) {
       super(props, context);


### PR DESCRIPTION
Fixes issue #5 where the noise.png's aren't being rendered because the export is wrong.